### PR TITLE
Fix AdvancedBan

### DIFF
--- a/upload/modules/Infractions/classes/AdvancedBan.php
+++ b/upload/modules/Infractions/classes/AdvancedBan.php
@@ -55,9 +55,9 @@ class AdvancedBan extends Infractions {
 			        $staff_uuid = $punishment->operator;
 
 			        if(!isset($staff_usernames[$punishment->operator])){
-				        $staff_query = DB::getInstance()->query('SELECT uuid FROM nl2_users WHERE username = ?', array($punishment->operator));
+				        $staff_query = DB::getInstance()->query('SELECT identifier FROM nl2_users_integrations WHERE username = ?', array($punishment->operator));
 				        if($staff_query->count()){
-					        $staff_uuid = $staff_query->first()->uuid;
+					        $staff_uuid = $staff_query->first()->identifier;
 					        $staff_usernames[$punishment->operator] = $staff_uuid;
 				        }
 			        } else {

--- a/upload/modules/Infractions/pages/infractions.php
+++ b/upload/modules/Infractions/pages/infractions.php
@@ -143,7 +143,7 @@ if(!isset($_GET['view']) && !isset($_GET['id'])){
             if(isset($result->removed_by_uuid) && isset($result->removed_by_name) && isset($result->removed_by_date)){
                 $removed_by_uuid = $result->removed_by_uuid;
                 $removed_by_name = $result->removed_by_name;
-                $removed_by_date = round(intval($result->removed_by_date) / 1000);
+                $removed_by_date = round(floatval($result->removed_by_date) / 1000);
                 $removed_by_link = $users_array[$result->removed_by_name]['profile'];
                 $removed_by_style = $users_array[$result->removed_by_name]['style'];
                 $removed_by_avatar = $users_array[$result->removed_by_name]['avatar'];

--- a/upload/modules/Infractions/pages/infractions.php
+++ b/upload/modules/Infractions/pages/infractions.php
@@ -143,7 +143,7 @@ if(!isset($_GET['view']) && !isset($_GET['id'])){
             if(isset($result->removed_by_uuid) && isset($result->removed_by_name) && isset($result->removed_by_date)){
                 $removed_by_uuid = $result->removed_by_uuid;
                 $removed_by_name = $result->removed_by_name;
-                $removed_by_date = round($result->removed_by_date / 1000);
+                $removed_by_date = round(intval($result->removed_by_date) / 1000);
                 $removed_by_link = $users_array[$result->removed_by_name]['profile'];
                 $removed_by_style = $users_array[$result->removed_by_name]['style'];
                 $removed_by_avatar = $users_array[$result->removed_by_name]['avatar'];


### PR DESCRIPTION
This PR fixes the errors thrown when attempting to use AdvancedBan for Infractions as a result of the changes that occurred to the NamelessMC database scheme